### PR TITLE
起動するポート番号を変えると403エラーが発生するためポート名を除くホスト名を取得するようにする

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -131,7 +131,7 @@ def NewSanic(
                 )
             if len([char for char in request.path.split("/") if char]) != 1:
                 return wrap_html(request, SanicException("ここは天国、二人で一つに！", 403))
-        elif request.host in ("free-rt.com", "52.139.184.62") or rawip:
+        elif request.server_name in ("free-rt.com", "52.139.184.62") or rawip:
             # ファイルが見つかればそのファイルを返す。
             # パスを準備する。
             path = request.path


### PR DESCRIPTION
例：
request.hostだとfree-rt.com:8080を返すがrequest.server_nameだとfree-rt.comだけを返す、編集したコードはrequest.hostがfree-rt.comの中に含まれているか確認するコードなのでfree-rt.com:8080が取得されると80ポートで起動したときと違う動作をする